### PR TITLE
Fast Zernike

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,7 @@
+name = "OpticsPolynomials"
+uuid = "b6abe8a2-4426-4bca-aa47-11264f1de821"
+authors = ["Brandon <brandondube@gmail.com> and contributors"]
+version = "0.1.0"
+
+[compat]
+julia = "1"

--- a/src/OpticsPolynomials.jl
+++ b/src/OpticsPolynomials.jl
@@ -1,0 +1,8 @@
+module OpticsPolynomials
+
+include("jacobi.jl")
+include("cheby.jl")
+include("legendre.jl")
+include("zernike.jl")
+
+end

--- a/src/cheby.jl
+++ b/src/cheby.jl
@@ -1,4 +1,3 @@
-import .Jacobi
 
 """
     cheby1(n, x)

--- a/src/jacobi.jl
+++ b/src/jacobi.jl
@@ -1,7 +1,6 @@
 
-module Jacobi
-
 export jacobi, jacobi_weight
+
 """
     jacobi_weight(α, β, x)
 
@@ -44,7 +43,7 @@ is also linear w.r.t. the size of argument x.
 """
 function jacobi(n, α, β, x)
 	if n == 0
-		return 1
+		return 1.0
 	elseif n == 1
 		return (α + 1) + (α + β + 2) * ((x-1)/2)
 	end
@@ -67,6 +66,4 @@ function jacobi(n, α, β, x)
 		Pn = ((b * Pnm1) - (c * Pnm2)) / a
 	end
 	return Pn
-end
-
 end

--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -1,4 +1,3 @@
-import .Jacobi
 
 """
     legendre(n, x)

--- a/src/zernike.jl
+++ b/src/zernike.jl
@@ -1,8 +1,4 @@
-import .Jacobi
-
-module Zernike
-
-export Zernike
+export Zernike,
        zernike_norm,
        zernike_nm_to_fringe,
        zernike_nm_to_ansi_j,
@@ -202,6 +198,4 @@ function zernike(n, m, ρ, θ; norm::Bool=true)
 		out *= zernike_norm(n,m)
 	end
     return out
-end
-
 end

--- a/src/zernike.jl
+++ b/src/zernike.jl
@@ -2,15 +2,14 @@ import .Jacobi
 
 module Zernike
 
-export (
-    zernike_norm,
-    zernike_nm_to_fringe,
-    zernike_nm_to_ansi_j,
-    zernike_ansi_j_to_nm,
-    zernike_noll_to_nm,
-    zernike_fringe_to_nm,
-    zernike_zero_separation
-)
+export zernike_norm,
+       zernike_nm_to_fringe,
+       zernike_nm_to_ansi_j,
+       zernike_ansi_j_to_nm,
+       zernike_noll_to_nm,
+       zernike_fringe_to_nm,
+       zernike_zero_separation
+
 
 """
     kronecker(i,j)


### PR DESCRIPTION
- add Project.toml file
- add top-level module (remove submodules) and include statements
- add fast struct-based zernike

The key difference between `zernike` and `Zernike` is that we can cache values like the norm value (instead of calculating every time) and forming closures over the polar and angular bases.

In the `zernike` implementation there is a type instability from `f = m < 0 ? sin : cos` for choosing the correct angular basis. This forces allocations, causing the poor performance. By abusing the type parameterization of `Zernike` the type instability is removed leading to extremely fast and stable evaluations. Below are some benchmarks.

```julia
julia> @btime zernike(10, 3, 2.5, 0.2);
  111.742 ns (8 allocations: 128 bytes)

julia> @btime Zernike(10, 3)(2.5, 0.2);
  11.339 ns (0 allocations: 0 bytes)
```
